### PR TITLE
Add note about oxen 7.x and earlier key backup

### DIFF
--- a/using-the-oxen-blockchain/oxen-service-node-guides/full-service-node-setup-guide.md
+++ b/using-the-oxen-blockchain/oxen-service-node-guides/full-service-node-setup-guide.md
@@ -487,6 +487,20 @@ oxen-sn-keys restore /var/lib/oxen/key_ed25519
 
 Alternatively, you can use a tool like `scp` to copy the file off-host for safekeeping.
 
+> Note that for older service nodes (installed before Oxen 8.x) the server will have *two* keys: the above, plus a legacy `/var/lib/oxen/key`.  You must additionally back up and restore this legacy key to restore such a service node, using:
+>
+> ```
+> oxen-sn-keys show /var/lib/oxen/key
+> ```
+>
+> to show the key, and if you need to restore it (note the "legacy" added to the command):
+>
+> ```
+> oxen-sn-keys restore-legacy /var/lib/oxen/key
+> ```
+>
+> If you are planning on unlocking and re-registering an older node with two keys, it is recommended to remove the legacy `/var/lib/oxen/key` *after* the registration expires, restart the oxen/lokinet/storage server services, and then register using the new, single key: this will leave you with just one key to back up and restore.  IMPORTANT: Never remove any keys on an active, registered service node!
+
 ### Conclusion
 
 Well done! Your Service Node is configured, operational, and will now begin receiving rewards.

--- a/using-the-oxen-blockchain/oxen-service-node-guides/setting-up-an-oxen-service-node.md
+++ b/using-the-oxen-blockchain/oxen-service-node-guides/setting-up-an-oxen-service-node.md
@@ -162,12 +162,17 @@ sudo apt install oxen-storage-server oxend lokinet-router
 
 ### Back-ups
 
-Backing up your Service Node's secret key. Will allow you to easily recover or migrate your Service Node
-
-Reveal SN secret key:
+To show backup information for your Service Node's secret key (for future recovery/migration):
 
 ```
 oxen-sn-keys show /var/lib/oxen/key_ed25519
+```
+
+For service nodes originally installed before 8.x there will be a /var/lib/oxen/key file that must
+also be backed up (if this file does not exist then you do not need it):
+
+```
+oxen-sn-keys show /var/lib/oxen/key
 ```
 
 Restore from SN secret key:
@@ -175,5 +180,13 @@ Restore from SN secret key:
 ```
 oxen-sn-keys restore /var/lib/oxen/key_ed25519
 ```
+
+and, *only* when restoring from an older installation with an additional `.../key` file:
+
+```
+oxen-sn-keys restore-legacy /var/lib/oxen/key
+```
+
+### Support
 
 Having trouble? Just [head to our Support section](../../support.md).


### PR DESCRIPTION
There are still many service nodes out there installed before oxen 8.x that have legacy keys.  This commit adds a note as the guide currently doesn't mention dealing with them at all, but they are critical if trying to move a pre-8.x node.