### PR TITLE
Remove deprecated apt-key usage; update deb repo urls

### DIFF
--- a/products-built-on-oxen/lokinet/guides/installing-on-linux-cli.md
+++ b/products-built-on-oxen/lokinet/guides/installing-on-linux-cli.md
@@ -33,13 +33,13 @@ You only need to do this step the first time you want to set up the Lokinet repo
 This first command installs the public key used to sign official Lokinet binaries.
 
 ```text
-curl -s https://deb.imaginary.stream/public.gpg | sudo apt-key add -
+sudo curl -so /etc/apt/trusted.gpg.d/oxen.gpg https://deb.oxen.io/pub.gpg
 ```
 
 The next command tells `apt` where to find the packages:
 
 ```text
-echo "deb https://deb.imaginary.stream $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/imaginary.stream.list
+echo "deb https://deb.oxen.io $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/oxen.list
 ```
 
 > Note: if you're running Linux Mint and get an error with this command, check out [Troubleshooting](installing-on-linux-cli.md#linux-mint-does-not-work-with-lsb-release).
@@ -105,6 +105,6 @@ sudo systemctl restart lokinet
 It has been reported that Linux Mint users may need to use the following command instead of the second command in [2. Installation](installing-on-linux-cli.md#2-installation):
 
 ```text
-echo "deb https://deb.imaginary.stream bionic main" | sudo tee /etc/apt/sources.list.d/imaginary.stream.list
+echo "deb https://deb.oxen.io focal main" | sudo tee /etc/apt/sources.list.d/oxen.list
 ```
 

--- a/products-built-on-oxen/lokinet/guides/linux-gui-install-guide.md
+++ b/products-built-on-oxen/lokinet/guides/linux-gui-install-guide.md
@@ -33,13 +33,13 @@ You only need to do this step the first time you want to set up the Lokinet repo
 This first command installs the public key used to sign official Lokinet binaries.
 
 ```text
-curl -s https://deb.imaginary.stream/public.gpg | sudo apt-key add -
+sudo curl -so /etc/apt/trusted.gpg.d/oxen.gpg https://deb.oxen.io/pub.gpg
 ```
 
 The next command tells `apt` where to find the packages:
 
 ```text
-echo "deb https://deb.imaginary.stream $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/imaginary.stream.list
+echo "deb https://deb.oxen.io $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/oxen.list
 ```
 
 Then resync your package repositories with:

--- a/products-built-on-oxen/lokinet/guides/secure-mumble-server-over-lokinet.md
+++ b/products-built-on-oxen/lokinet/guides/secure-mumble-server-over-lokinet.md
@@ -48,11 +48,11 @@ Success? Congrats, you’re ready to move on to the next step:
 
 To install Lokinet, we need to add the Lokinet repository. Run the following command to install the public key used by the Lokinet dev team to sign Lokinet binaries:
 
-`curl -s https://deb.imaginary.stream/public.gpg | sudo apt-key add -`
+`sudo curl -so /etc/apt/trusted.gpg.d/oxen.gpg https://deb.oxen.io/pub.gpg`
 
 Then run the following command to tell `apt` where to find the Lokinet packages:
 
-`echo "deb https://deb.imaginary.stream $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/imaginary.stream.list`  
+`echo "deb https://deb.oxen.io $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/oxen.list`
 
 
 Next, update your repository package lists again with:


### PR DESCRIPTION
- apt-key has been deprecated for quite a while but some of the docs
  packages didn't get updated.

- Replace deb.imaginary.stream with the official repo URL deb.oxen.io;
  the former still works, but we changed most places to the new name a
  while ago.

- Linux Mint line was referencing bionic, but should be focal for
  current Mint releases.