### PR TITLE
Fix link to troubleshooting guide

### DIFF
--- a/products-built-on-oxen/lokinet/guides/linux-gui-install-guide.md
+++ b/products-built-on-oxen/lokinet/guides/linux-gui-install-guide.md
@@ -31,4 +31,4 @@ Simply jump into the lokinet-gui client and click the large green power button.
 
 Head over to [Exit nodes](../exit-nodes.md) or [Accessing SNApps](../snapps/accessing-snapps.md) for an overview of the exciting things you can do with Lokinet up and running!
 
-See the troubleshooting guide [here](../linux-troubleshooting.md) if you have issues.
+See the troubleshooting guide [here](./linux-troubleshooting.md) if you have issues.


### PR DESCRIPTION
Ideally this should probably point to the hosted instance instead of the GitHub repo: https://docs.oxen.io/oxen-docs/products-built-on-oxen/lokinet/guides/linux-gui-install-guide